### PR TITLE
Allowing passing of custom json file name in the config object

### DIFF
--- a/src/system.cachebuster.js
+++ b/src/system.cachebuster.js
@@ -11,6 +11,7 @@
     
     function config(options) {
         enableLogs = (options.enableLogs===undefined ? false : !!options.enableLogs);
+        jsonFileName = (options.jsonFileName === undefined ? "system.cachebuster.json" : options.jsonFileName);
     }
 
     function log(message) {
@@ -47,7 +48,10 @@
         }
 
         return loadHashTablePromise = new Promise(function(resolve, reject) {
-            var url = "/" + jsonFileName + "?v=" + new Date().valueOf();
+            var isAbs = jsonFileName.indexOf('://') != -1;
+            var baseJsonFileName = isAbs ? jsonFileName : '/' + jsonFileName;
+            var url = baseJsonFileName + "?v=" + new Date().valueOf();
+
             log("Loading hash table from: " + url);
             var oReq = new XMLHttpRequest();
             oReq.open("GET", url);


### PR DESCRIPTION
Fixing #3 . The filename can now be supplied as follows:

```
SystemCacheBuster.config({
    jsonFileName: 'foo/system.cachebuster.json'
});
```

Also absolute URLs are supported, so you can also pass something like

```
jsonFileName: 'https://example.com/system.cachebuster.json'
```